### PR TITLE
fix: add thicker border to theme toggle button

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -110,10 +110,9 @@ header h1 {
     position: relative;
     width: 44px;
     height: 44px;
-    border: none;
     border-radius: 50%;
     background: var(--background);
-    border: 1px solid var(--border-color);
+    border: 3px solid var(--primary-color);
     color: var(--text-primary);
     cursor: pointer;
     display: flex;
@@ -121,6 +120,7 @@ header h1 {
     justify-content: center;
     transition: all 0.3s ease;
     overflow: hidden;
+    box-shadow: 0 0 0 1px var(--border-color);
 }
 
 .theme-toggle:hover {


### PR DESCRIPTION
Adds a thicker outside contour to the theme toggle button for better visibility.

- Increased border from 1px to 3px
- Uses primary color for the border
- Adds box-shadow for extra outer ring

Closes #3

Generated with [Claude Code](https://claude.ai/code)